### PR TITLE
#10 modify deprecated implode syntax

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -166,7 +166,7 @@ class Product extends AbstractHelper
             ->setDecription($this->faker->paragraphs(rand(1, 4), true))
             ->setShortDescription($this->faker->paragraph)
             ->setMetaTitle(ucwords($this->faker->words(rand(1, 4), true)))
-            ->setMetaKeyword(implode($this->faker->words(rand(10, 20)), ', '))
+            ->setMetaKeyword(implode(', ', $this->faker->words(rand(10, 20))))
             ->setMetaDescription($this->faker->text(200))
             ->setWeight($this->faker->randomFloat(4, 0, 10))
             ->setStatus(rand(1, 2))


### PR DESCRIPTION
Fixes #10. It's compatible with (PHP 4, PHP 5, PHP 7, PHP 8) as described here: https://www.php.net/manual/en/function.implode.php